### PR TITLE
A few modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,23 +26,28 @@ secret keys.
 
 Options:
 
-* `-d`, `--debug`: log additional informations, useful for debugging purposes
+* `-d`, `--debug`: log additional information, useful for debugging purposes
 * `-s STORE`, `--store STORE`: path of the password-store directory, defaults to
   `~/.password-store`
 * `-p PORT`, `--port PORT`: port to use, defaults to `3000`
+* `-u URLPREFIX`, `--urlpre URLPREFIX`: url subdirectory being used, for example
+  `/pass-web` for a server at `https://example.com/pass-web`
+* `-k KEY`, `--key KEY`: full path to key file to use for ssl
+* `-c CERT`, `--cert CERT`: full path to certificate file to use for ssl
+* `-h HTPASSWD`, `--htpasswd HTPASSWD`: htpasswd file to use for initial web page
+  basic authentication and access (may be different than gpg password). If
+  ommitted, no authentication will be used.
 
-## Example
+## Examples
 
 ```
 $ pass-web -p 9082 <(gpg --export-secret-keys -a)
+$ pass-web -p 8081 -s /path/to/pass/store -u /pass-web -k /path/to/ssl/key -c /path/to/ssl/cert secretKeyFile -p 34567 -h /path/to/htpasswd
 ```
 
 ## HTTPS concerns
 
-In order to discourage from using `pass-web` on plain, unsecure HTTP, it will always bind
-to `127.0.0.1`. Thus, you will need to configure a reverse proxy to use it externaly,
-ideally with HTTPS support. You can easily have free SSL certificates and configuring a
-HTTP server (like nginx) to do this. It's not that hard, just search the Web.
+You may want to configure a reverse proxy to use it externaly, pointing to the subdirectory used with the `-u` switch, above. You can use an HTTP server (like nginx) to do this.
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You will need nodejs 5+ to run it.
 ## Usage
 
 ```
-pass-web [-d] [-s STORE] [-p PORT] pgpkey...
+pass-web [-d] [-s STORE] [-p PORT] [-u URLPREFIX] [-k KEY] [-c CERT] [-h HTPASSWD] pgpkey...
 ```
 
 Launch the HTTP server. The `pgpkey` arguments are paths to the exported (armored, encrypted) pgp

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "body-parser": "^1.14.1",
     "express": "^4.13.3",
     "kbpgp": "^2.0.48",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "http-auth": "^2.2.8"
   },
   "devDependencies": {
     "babel": "^6.1.18",

--- a/server/index.js
+++ b/server/index.js
@@ -178,8 +178,8 @@ function apiRouter(conf) {
 function launchApp(conf) {
   const app = express();
 
-  app.use(express.static(path.join(__dirname, "..", "dist")));
-  app.use("/api", apiRouter(conf));
+  app.use(args.urlpre || "/", express.static(path.join(__dirname, "..", "dist")));
+  app.use((args.urlpre || "") + "/api", apiRouter(conf));
   
   app.httpsListen = function() {
     var server = https.createServer({
@@ -191,7 +191,7 @@ function launchApp(conf) {
   
   app.httpsListen(conf.port, "localhost", function () {
     const address = this.address();
-    log.info`Server listening on https://${address.address}:${address.port}`;
+    log.info`Server listening on https://${address.address}:${address.port}${args.urlpre}`;
   });
 }
 
@@ -201,7 +201,8 @@ const args = parseArgs(process.argv, {
     store: [ "s" ],
     port: [ "p" ],
     key: [ "k" ],
-    cert: [ "c" ]
+    cert: [ "c" ],
+    urlpre: [ "u" ]
   },
   boolean: [ "debug" ],
 });

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 
+const https = require('https');
 const fs = require("fs");
 const path = require("path");
 const express = require("express");
@@ -179,10 +180,18 @@ function launchApp(conf) {
 
   app.use(express.static(path.join(__dirname, "..", "dist")));
   app.use("/api", apiRouter(conf));
-
-  app.listen(conf.port, "localhost", function () {
+  
+  app.httpsListen = function() {
+    var server = https.createServer({
+      key: fs.readFileSync(args.key),
+      cert: fs.readFileSync(args.cert)
+    }, this);
+    return server.listen.apply(server, arguments);
+  };
+  
+  app.httpsListen(conf.port, "localhost", function () {
     const address = this.address();
-    log.info`Server listening on http://${address.address}:${address.port}`;
+    log.info`Server listening on https://${address.address}:${address.port}`;
   });
 }
 
@@ -191,6 +200,8 @@ const args = parseArgs(process.argv, {
     debug: [ "d" ],
     store: [ "s" ],
     port: [ "p" ],
+    key: [ "k" ],
+    cert: [ "c" ]
   },
   boolean: [ "debug" ],
 });


### PR DESCRIPTION
Most of these modifications can be handled in nginx (or some other server), but they were fairly easy to make in node/express. I added command line arguments for each of them, although the command line arguments are getting numerous at this point (perhaps a config file of some sort would be better?)

First, https is now required and the https module is used for everything now. The certificate and key files are refereced in the corresponding command line arguments.

Next, I added the ability to use a url sudirectory, such as www.example.com/pass-web

Finally I added the http-auth module for access to the page via Basic Authentication. Might be overkill since access to the password store itself requires the gpg password, but there is no additional inconvenience, really, so I thought I'd add it.

Feel free to take any or all of these changes. Very glad I found this project! Thanks